### PR TITLE
Initialize share notifications with the current user

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -119,7 +119,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			// don't send a mail to the user who shared the file
 			$recipientList = array_diff($recipientList, array(\OCP\User::getUser()));
 
-			$mailNotification = new OC\Share\MailNotifications();
+			$mailNotification = new OC\Share\MailNotifications(\OCP\User::getUser());
 			$result = $mailNotification->sendInternalShareMail($recipientList, $itemSource, $itemType);
 
 			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);


### PR DESCRIPTION
Currently the constructor of MailNotification is called without an argument. This forces the default sender address "sharing-noreply" later on which is combined with the displayName of the current user. This leads to a confusing sender "Username" <sharing-noreply@domain.com>. Users will see a valid username and might not notice the unvalid email address.

This works fine for me in 7.0.5 and should fix #13468
I guess it should also work for 8.x, what do you think?
